### PR TITLE
update stkaave interactions

### DIFF
--- a/contracts/Strategy.sol
+++ b/contracts/Strategy.sol
@@ -750,9 +750,9 @@ contract Strategy is BaseStrategy {
         uint256 COOLDOWN_SECONDS = IStakedAave(stkAave).COOLDOWN_SECONDS();
         uint256 UNSTAKE_WINDOW = IStakedAave(stkAave).UNSTAKE_WINDOW();
         return
-            block.timestamp > cooldownStartTimestamp.add(COOLDOWN_SECONDS) ||
-            block.timestamp.sub(cooldownStartTimestamp.add(COOLDOWN_SECONDS)) <= UNSTAKE_WINDOW ||
-            cooldownStartTimestamp == 0;
+            cooldownStartTimestamp != 0 &&
+            block.timestamp > cooldownStartTimestamp.add(COOLDOWN_SECONDS) &&
+            block.timestamp <= cooldownStartTimestamp.add(COOLDOWN_SECONDS).add(UNSTAKE_WINDOW);
     }
 
     function _checkAllowance(

--- a/contracts/Strategy.sol
+++ b/contracts/Strategy.sol
@@ -748,16 +748,10 @@ contract Strategy is BaseStrategy {
             IStakedAave(stkAave).stakersCooldowns(address(this));
         uint256 COOLDOWN_SECONDS = IStakedAave(stkAave).COOLDOWN_SECONDS();
         uint256 UNSTAKE_WINDOW = IStakedAave(stkAave).UNSTAKE_WINDOW();
-        if (block.timestamp >= cooldownStartTimestamp.add(COOLDOWN_SECONDS)) {
-            return
-                block.timestamp.sub(
-                    cooldownStartTimestamp.add(COOLDOWN_SECONDS)
-                ) <=
-                UNSTAKE_WINDOW ||
-                cooldownStartTimestamp == 0;
-        }
-
-        return false;
+        return
+            block.timestamp > cooldownStartTimestamp.add(COOLDOWN_SECONDS) ||
+            block.timestamp.sub(cooldownStartTimestamp.add(COOLDOWN_SECONDS)) <= UNSTAKE_WINDOW ||
+            cooldownStartTimestamp == 0;
     }
 
     function _checkAllowance(

--- a/contracts/Strategy.sol
+++ b/contracts/Strategy.sol
@@ -616,8 +616,13 @@ contract Strategy is BaseStrategy {
             );
 
             // request start of cooldown period
+            uint256 cooldownStartTimestamp =
+            IStakedAave(stkAave).stakersCooldowns(address(this));
+            uint256 COOLDOWN_SECONDS = IStakedAave(stkAave).COOLDOWN_SECONDS();
+            uint256 UNSTAKE_WINDOW = IStakedAave(stkAave).UNSTAKE_WINDOW();
             if (IERC20(address(stkAave)).balanceOf(address(this)) > 0 &&
-                IStakedAave(stkAave).stakersCooldowns(address(this)) == 0) {
+                (cooldownStartTimestamp == 0) ||
+                block.timestamp > cooldownStartTimestamp.add(COOLDOWN_SECONDS).add(UNSTAKE_WINDOW)) {
                 stkAave.cooldown();
             }
         }

--- a/contracts/Strategy.sol
+++ b/contracts/Strategy.sol
@@ -617,7 +617,8 @@ contract Strategy is BaseStrategy {
             );
 
             // request start of cooldown period
-            if (IERC20(address(stkAave)).balanceOf(address(this)) > 0) {
+            if (IERC20(address(stkAave)).balanceOf(address(this)) > 0 &&
+                IStakedAave(stkAave).stakersCooldowns(address(this)) == 0) {
                 stkAave.cooldown();
             }
         }

--- a/contracts/Strategy.sol
+++ b/contracts/Strategy.sol
@@ -582,11 +582,10 @@ contract Strategy is BaseStrategy {
             uint256 stkAaveBalance =
                 IERC20(address(stkAave)).balanceOf(address(this));
             if (stkAaveBalance > 0 && _checkCooldown()) {
+                // claim AAVE rewards
+                stkAave.claimRewards(address(this), type(uint256).max);
                 stkAave.redeem(address(this), stkAaveBalance);
             }
-
-            // claim AAVE rewards
-            stkAave.claimRewards(address(this), type(uint256).max);
 
             // sell AAVE for want
             // a minimum balance of 0.01 AAVE is required


### PR DESCRIPTION
minor fix on stkaave interactions (checking &calling)

one small observation is that during checking cooldown, in stkaave code it's ">", so we had better use it instead of ">=". o/w it'll fail in an edge case that a harvest is called at the same timestamp of `cooldownStartTimestamp + COOLDOWN_SECONDS`.